### PR TITLE
Duplicate conversation names solution

### DIFF
--- a/chatalysis/program/gui.py
+++ b/chatalysis/program/gui.py
@@ -312,13 +312,16 @@ class WindowIndividual(Window):
         :param original_names: list of all available conversations, stored as tuples (name, chat_id)
         :return: dict with conversation names
         """
-        conversations = OrderedDict()
+        conversations: OrderedDict[str, str] = OrderedDict()
 
         for name, chat_id in original_names:
             if name in conversations:
-                chat_id_2 = conversations.get(name)
-                new_name_1 = f"{name}_({self.Program.source.conversation_size(chat_id)}_messages)"
-                new_name_2 = f"{name}_({self.Program.source.conversation_size(chat_id_2)}_messages)"
+                src = self.Program.source
+                chat_id_2 = str(conversations.get(name))
+
+                # the listbox splits entries by spaces, therefore a no-break space has to be used here
+                new_name_1 = f"{name}\u00a0({src.conversation_size(chat_id)}\u00a0messages)"
+                new_name_2 = f"{name}\u00a0({src.conversation_size(chat_id_2)}\u00a0messages)"
 
                 conversations.pop(name)
                 conversations[new_name_1] = chat_id

--- a/chatalysis/sources/facebook_source.py
+++ b/chatalysis/sources/facebook_source.py
@@ -24,11 +24,7 @@ class FacebookSource(MessageSource):
     def __init__(self, path: str):
         MessageSource.__init__(self, path)
         self.folders: list[Path] = []
-        self.chat_ids: list[str] = []  # list of all conversations identified by their chat ID
-
-        # Mapping of condensed conversation names (user input) to chat IDs. Since a conversation name
-        # can represent multiple chats, the chat IDs are stored in a list.
-        self.chat_id_map: dict[str, list[chat_id_str]] = {}
+        self.chat_ids: set[str] = set()  # list of all conversations identified by their chat ID
 
         # Intermediate cache of the extracted but not yet processed messages. The values stored are tuples of
         # messages, names of the chat participants, chat title and chat type. Once the messages have been processed,
@@ -43,16 +39,7 @@ class FacebookSource(MessageSource):
 
     # region Public API
 
-    def get_chat(self, chat_name: str) -> FacebookStats:
-        possible_chat_ids = self.chat_id_map[chat_name]
-
-        # Check for chat collisions
-        if len(possible_chat_ids) == 1:
-            chat_id = possible_chat_ids[0]
-        else:
-            # TODO create a GUI dialog for this case
-            chat_id = possible_chat_ids[0]
-
+    def get_chat(self, chat_id: str) -> FacebookStats:
         if chat_id not in self.chats_cache:
             self._compile_chat_data(chat_id)
         return self.chats_cache[chat_id]
@@ -105,9 +92,161 @@ class FacebookSource(MessageSource):
             elif chat_type == StatsType.GROUP:
                 groups[title] = len(messages)
 
-        top_individual = dict(sorted(chats.items(), key=lambda item: item[1], reverse=True)[0:10])
-        top_group = dict(sorted(groups.items(), key=lambda item: item[1], reverse=True)[0:5])
+        top_individual = sorted(chats.items(), key=lambda item: item[1], reverse=True)[0:10]
+        top_group = sorted(groups.items(), key=lambda item: item[1], reverse=True)[0:5]
         return top_individual, top_group
+
+    def conversation_size(self, chat: str) -> int:
+        messages, _, _, _ = self._get_messages(chat)
+        return len(messages)
+
+    # endregion
+
+    # region Chat processing
+
+    def _compile_chat_data(self, chat_id: str):
+        """Gets all the chat data, processes it and stores it as a Chat object in the cache.
+
+        :param chat_id: name of the chat to process
+        """
+        if chat_id in self.messages_cache:
+            # fetch unprocessed extracted data
+            messages, participants, title, chat_type = self.messages_cache[chat_id]
+            self.messages_cache.pop(chat_id)
+        else:
+            messages, participants, title, chat_type = self._prepare_chat_data(chat_id)
+
+        self.chats_cache[chat_id] = self._process_messages(messages, participants, title, chat_type)
+
+    def _prepare_chat_data(self, chat_id: chat_id_str) -> tuple[list, list, str, StatsType]:
+        """Extracts the chat data and decodes the messages
+
+        :param chat_id: ID of the chat to process
+        :return: messages - list of messages
+                 title - name of the conversation,
+                 participants - names of conversation participants
+                 chat_type - type of chat (regular chat, group chat)
+        """
+        messages, participants, title, chat_type = self._get_messages(chat_id)
+        messages = sorted(messages, key=lambda k: k["timestamp_ms"])
+        self._decode_messages(messages)
+        return messages, participants, title, chat_type
+
+    def _get_paths(self, chat_id: str) -> list[Path]:
+        """Gets paths to the inbox folders with desired chat.
+
+        :param chat_id: chat ID of the desired chat
+        :return: list of paths to the inbox folders
+        """
+        paths = []
+
+        for folder in self.folders:
+            path_name = f"{folder}/{chat_id}"
+            if os.path.isdir(path_name):
+                paths.append(Path(path_name))
+
+        return paths
+
+    def _get_jsons(self, chat_id: str) -> list[Path]:
+        """Gets the json(s) with messages for a particular chat
+
+        :param chat_id: chat ID of the desired chat
+        :return: list of JSON files with the messages
+        """
+        paths = self._get_paths(chat_id)
+        jsons = []
+
+        for ch in paths:
+            for file in list_folder(ch):
+                if file.startswith("message") and file.endswith(".json"):
+                    jsons.append(ch / file)
+        if not jsons:
+            raise Exception("No JSON files in this chat")
+
+        return jsons
+
+    def _get_participants(self, chat: dict) -> list[str]:
+        """Gets names of the participants in the chat.
+
+        :param chat: raw chat data
+        :return: list of chat participants
+        """
+        participants = []
+        for i in chat["participants"]:
+            participants.append(self._decode(i["name"]))
+        if len(participants) == 1:
+            participants.append(participants[0])
+        return participants
+
+    def _get_messages(self, chat_id: chat_id_str) -> tuple[list[dict], list[str], str, StatsType]:
+        """Gets the chat data (messages, names of the participants, chat title and chat type)
+
+        :param chat_id: ID of the chat to process
+        :return: messages - list of messages
+                 title - name of the conversation,
+                 participants - names of conversation participants
+                 chat_type - type of chat (regular chat, group chat)
+        """
+        jsons = self._get_jsons(chat_id)
+        messages = []
+
+        first = True
+        for json_file in jsons:
+            with open(json_file, "r") as data_file:
+                data = json.load(data_file)
+                messages.extend(data["messages"])
+
+                if first:
+                    # get title, participants and chat type, which are the same across all JSONs
+                    title = self._decode(data["title"])
+                    participants = self._get_participants(data)
+
+                    if data["thread_type"] == "RegularGroup":
+                        chat_type = StatsType.GROUP
+                    else:
+                        chat_type = StatsType.REGULAR
+
+                    first = False
+
+        return messages, participants, title, chat_type
+
+    @abc.abstractmethod
+    def _process_messages(
+        self, messages: list, participants: list[str], title: str, stats_type: StatsType = None
+    ) -> FacebookStats:
+        """Processes the messages, produces raw stats and stores them in a Chat object.
+
+        :param messages: list of messages to process
+        :param participants: list of the chat participants
+        :param title: title of the chat
+        :param stats_type: type of stats (regular / group chat / overall personal)
+        :return: FacebookMessengerChat with the processed chats
+        """
+
+    def _process_reactions(self, message: dict, name: str, participants: list[str], reactions: dict):
+        """Extracts reactions from a message and expands the reaction stats.
+
+        :param message: message to analyze
+        :param name: name of the message author
+        :param participants: list of the chat participants
+        :param reactions: dictionary with reaction stats
+        :return: expanded reactions dict
+        """
+        for r in message["reactions"]:
+            if r["reaction"] == self._decode("\u00e2\u009d\u00a4"):
+                reaction = "❤️"
+            else:
+                reaction = r["reaction"]
+            reactions["total"] += 1
+            reactions["types"][reaction] = 1 + reactions["types"].get(reaction, 0)
+            if name in participants:
+                reactions["got"][name]["total"] += 1
+                reactions["got"][name][reaction] = 1 + reactions["got"][name].get(reaction, 0)
+                if r["actor"] in participants:
+                    reactions["gave"][r["actor"]]["total"] += 1
+                    reactions["gave"][r["actor"]][reaction] = 1 + reactions["gave"][r["actor"]].get(reaction, 0)
+
+        return reactions
 
     @staticmethod
     def _extract_emojis(message: dict, emojis: dict) -> dict:
@@ -137,143 +276,6 @@ class FacebookSource(MessageSource):
 
     # endregion
 
-    # region Chat processing
-
-    def _compile_chat_data(self, chat_id: str):
-        """Gets all the chat data, processes it and stores it as a Chat object in the cache.
-
-        :param chat_id: name of the chat to process
-        """
-        if chat_id in self.messages_cache:
-            # fetch unprocessed extracted data
-            messages, participants, title, chat_type = self.messages_cache[chat_id]
-            self.messages_cache.pop(chat_id)
-        else:
-            messages, participants, title, chat_type = self._prepare_chat_data(chat_id)
-
-        self.chats_cache[chat_id] = self._process_messages(messages, participants, title, chat_type)
-
-    def _prepare_chat_data(self, chat_id: str) -> tuple[list, list, str, StatsType]:
-        """Extracts the chat data (messages, names of the participants, chat title and chat type)
-
-        :param chat_id: name of the chat to process
-        :return: messages - list of messages
-                 title - name of the conversation,
-                 participants - names of conversation participants
-                 chat_type - type of chat (regular chat, group chat)
-        """
-        chat_paths = self._get_paths(chat_id)
-        jsons = self._get_jsons(chat_paths)
-        messages = []
-
-        first = True
-        for json_file in jsons:
-            with open(json_file, "r") as data_file:
-                data = json.load(data_file)
-                messages.extend(data["messages"])
-
-                if first:
-                    # get title, participants and chat type, which are the same across all JSONs
-                    title = self._decode(data["title"])
-                    participants = self._get_participants(data)
-
-                    if data["thread_type"] == "RegularGroup":
-                        chat_type = StatsType.GROUP
-                    else:
-                        chat_type = StatsType.REGULAR
-
-                    first = False
-
-        messages = sorted(messages, key=lambda k: k["timestamp_ms"])
-        self._decode_messages(messages)
-        return messages, participants, title, chat_type
-
-    def _get_paths(self, chat_id: str) -> list[Path]:
-        """Gets paths to the inbox folders with desired chat.
-
-        :param chat_id: chat ID of the desired chat
-        :return: list of paths to the inbox folders
-        """
-        paths = []
-
-        for folder in self.folders:
-            path_name = f"{folder}/{chat_id}"
-            if os.path.isdir(path_name):
-                paths.append(Path(path_name))
-
-        return paths
-
-    @staticmethod
-    def _get_jsons(chat_paths: list[Path]) -> list[Path]:
-        """Gets the json(s) with messages for a particular chat
-
-        :param chat_paths: list of paths to the inbox folders of the chat
-        :return: list of JSON files with the messages
-        """
-        jsons = []
-
-        for ch in chat_paths:
-            for file in list_folder(ch):
-                if file.startswith("message") and file.endswith(".json"):
-                    jsons.append(ch / file)
-        if not jsons:
-            raise Exception("No JSON files in this chat")
-
-        return jsons
-
-    def _get_participants(self, chat: dict) -> list[str]:
-        """Gets names of the participants in the chat.
-
-        :param chat: raw chat data
-        :return: list of chat participants
-        """
-        participants = []
-        for i in chat["participants"]:
-            participants.append(self._decode(i["name"]))
-        if len(participants) == 1:
-            participants.append(participants[0])
-        return participants
-
-    @abc.abstractmethod
-    def _process_messages(
-        self, messages: list, participants: list[str], title: str, stats_type: StatsType = None
-    ) -> FacebookStats:
-        """Processes the messages, produces raw stats and stores them in a Chat object.
-
-        :param messages: list of messages to process
-        :param participants: list of the chat participants
-        :param title: title of the chat
-        :param stats_type: type of stats (regular / group chat / overall personal)
-        :return: FacebookMessengerChat with the processed chats
-        """
-
-    def _process_reactions(self, message: dict, name: str, participants: list[str], reactions: dict):
-        """Extracts reactions from a message and expands the reaction stats.
-
-        :param message: message to analyze
-        :param name: name of the message author
-        :param participants: list of the chat participants
-        :param reactions: dictionary with reaction statsre
-        :return: expanded reactions dict
-        """
-        for r in message["reactions"]:
-            if r["reaction"] == self._decode("\u00e2\u009d\u00a4"):
-                reaction = "❤️"
-            else:
-                reaction = r["reaction"]
-            reactions["total"] += 1
-            reactions["types"][reaction] = 1 + reactions["types"].get(reaction, 0)
-            if name in participants:
-                reactions["got"][name]["total"] += 1
-                reactions["got"][name][reaction] = 1 + reactions["got"][name].get(reaction, 0)
-                if r["actor"] in participants:
-                    reactions["gave"][r["actor"]]["total"] += 1
-                    reactions["gave"][r["actor"]][reaction] = 1 + reactions["gave"][r["actor"]].get(reaction, 0)
-
-        return reactions
-
-    # endregion
-
     # region Data source processing
 
     def _load_message_folders(self):
@@ -287,16 +289,7 @@ class FacebookSource(MessageSource):
         for folder in self.folders:
             for chat_id in list_folder(folder):
                 if not chat_id.startswith("._"):
-                    name = chat_id.split("_")[0].lower()
-
-                    if name not in self.chat_id_map:
-                        self.chat_id_map[name] = [chat_id.lower()]
-                    else:
-                        previous_id = self.chat_id_map[name][0]
-                        if chat_id != previous_id:
-                            self.chat_id_map[name].append(chat_id.lower())
-
-                    self.chat_ids.append(chat_id)
+                    self.chat_ids.add(chat_id)
 
     # endregion
 

--- a/chatalysis/sources/message_source.py
+++ b/chatalysis/sources/message_source.py
@@ -33,3 +33,10 @@ class MessageSource(abc.ABC):
         :return: dictionary of top 10 individual conversations & top 5 group chats
                  with the structure {conversation name: number of messages}
         """
+
+    @abc.abstractmethod
+    def conversation_size(self, chat: str) -> int:
+        """Gets amount of messages in a conversation.
+
+        :param chat: name of the conversation / chat ID
+        """


### PR DESCRIPTION
When two conversations have the same name, the listbox entry will also show number of messages in the conversation (it's unlikely that the amount of messages would also be the same).

~However, it seems that listbox splits entries by spaces so the entry format has to be like this: conversationname_(X_messages). It's a little ugly but it works.~