### PR TITLE
Rework chat_id and paths loading to correctly handle new data

### DIFF
--- a/chatalysis/program/gui.py
+++ b/chatalysis/program/gui.py
@@ -1,5 +1,6 @@
 import ctypes
 import sys
+import os
 import tkinter as tk
 import tkmacosx as tkm
 import traceback
@@ -340,13 +341,11 @@ class WindowIndividual(tk.Toplevel):
         for chat_id, chat_paths in self.Program.source.chat_ids.items():
             # get the latest "name" of the conversation
             if len(chat_paths) > 1:
-                latest_chat_time = max([creation_date(k) for k in chat_paths])
-                for path in chat_paths:
-                    if creation_date(path) == latest_chat_time:
-                        name = path._parts[-1].split("_")[0]
-                        break
+                creation_dates = [creation_date(k) for k in chat_paths]
+                idx = max(range(len(creation_dates)), key=creation_dates.__getitem__)
+                name = os.path.split(chat_paths[idx])[-1].split("_")[0]
             else:
-                name = chat_paths[0]._parts[-1].split("_")[0]
+                name = os.path.split(chat_paths[0])[-1].split("_")[0]
 
             if name in conversations:
                 src = self.Program.source

--- a/chatalysis/sources/facebook_source.py
+++ b/chatalysis/sources/facebook_source.py
@@ -26,9 +26,9 @@ class FacebookSource(MessageSource):
     def __init__(self, path: str):
         MessageSource.__init__(self, path)
         self.folders: list[Path] = []
-        self.chat_ids: dict[
-            chat_id_str, list[Path]
-        ] = {}  # dict of all conversations identified by their chat ID, with their paths
+
+        # dict of all conversations identified by their chat ID, with their paths
+        self.chat_ids: dict[chat_id_str, list[Path]] = {}
 
         # Intermediate cache of the extracted but not yet processed messages. The values stored are tuples of
         # messages, names of the chat participants, chat title and chat type. Once the messages have been processed,
@@ -94,7 +94,7 @@ class FacebookSource(MessageSource):
             # remove emoji because it ruins the aligning of the output text
             title = emoji.replace_emoji(title, "")
             if not title:
-                title = f"chat_id: {chat_id}"
+                title = f"chat_id: {chat_id}"  # edge case - title is comprised of just emoji
 
             if chat_type == StatsType.REGULAR:
                 chats[title] = len(messages)
@@ -284,15 +284,14 @@ class FacebookSource(MessageSource):
         """Load all chats from the source and get their relevant paths"""
         for folder in self.folders:
             for chat_id in list_folder(folder):
-                if not chat_id.startswith("._"):
-                    path_to_chat_folder = Path(f"{folder}/{chat_id}")
-                    if any(x.endswith(".json") for x in list_folder(path_to_chat_folder)):
-                        if "_" in chat_id:
-                            chat_id = chat_id.split("_", 1)[1]
-                        if chat_id in self.chat_ids:
-                            self.chat_ids[chat_id].append(path_to_chat_folder)
-                        else:
-                            self.chat_ids[chat_id] = [path_to_chat_folder]
+                path_to_chat_folder = Path(f"{folder}/{chat_id}")
+                if any(x.endswith(".json") for x in list_folder(path_to_chat_folder)):
+                    if "_" in chat_id:
+                        chat_id = chat_id.split("_", 1)[1]
+                    if chat_id in self.chat_ids:
+                        self.chat_ids[chat_id].append(path_to_chat_folder)
+                    else:
+                        self.chat_ids[chat_id] = [path_to_chat_folder]
 
     # endregion
 

--- a/chatalysis/utils/utility.py
+++ b/chatalysis/utils/utility.py
@@ -72,3 +72,23 @@ def download_latest() -> None:
     """Downloads the latest version of chatalysis via browser"""
     latest = requests.get("https://api.github.com/repos/stepva/chatalysis/releases/latest").json()["name"]
     webbrowser.open(f"https://github.com/stepva/chatalysis/archive/refs/tags/{latest}.zip")
+
+
+def creation_date(path_to_file: Path) -> float:
+    """
+    Note: stolen from the internets
+    Try to get the date that a file was created, falling back to when it was
+    last modified if that isn't possible.
+    See http://stackoverflow.com/a/39501288/1709587 for explanation.
+    """
+    if sys.platform == "win32" or sys.platform == "cygwin":
+        return os.path.getctime(path_to_file)
+    else:
+        stat = os.stat(path_to_file)
+        try:
+            # using getattr() because mypy is dumb :) see https://github.com/python/mypy/issues/8823
+            return getattr(stat, "st_birthtime")
+        except AttributeError:
+            # We're probably on Linux. No easy way to get creation dates here,
+            # so we'll settle for when its content was last modified.
+            return getattr(stat, "st_mtime")

--- a/chatalysis/utils/utility.py
+++ b/chatalysis/utils/utility.py
@@ -51,7 +51,11 @@ def list_folder(path: Path) -> list[str]:
     :param path: path to the directory
     :return: list of strings with the file names
     """
-    return [str(folder) for folder in os.listdir(path) if str(folder).find("DS_Store") == -1]
+    return [
+        str(folder)
+        for folder in os.listdir(path)
+        if str(folder).find("DS_Store") == -1 and str(folder).find("._") == -1
+    ]
 
 
 def is_latest_version() -> bool:
@@ -75,11 +79,8 @@ def download_latest() -> None:
 
 
 def creation_date(path_to_file: Path) -> float:
-    """
-    Note: stolen from the internets
-    Try to get the date that a file was created, falling back to when it was
-    last modified if that isn't possible.
-    See http://stackoverflow.com/a/39501288/1709587 for explanation.
+    """Get the date when a file was created or, if that isn't possible, the time it was last modified.
+    Note: stolen from the internets. See http://stackoverflow.com/a/39501288/1709587 for explanation.
     """
     if sys.platform == "win32" or sys.platform == "cygwin":
         return os.path.getctime(path_to_file)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = chatalysis
 description = Analyse and visualise your Facebook Messenger and Instagram chats
 author = Štěpán Vácha, Filip Miškařík
-version = 1.1.1
+version = attr: __version__
 license = MIT
 license_file = LICENSE
 platforms = unix, linux, osx, cygwin, win32
@@ -27,7 +27,7 @@ install_requires =
 
 python_requires = >=3.10
 package_dir =
-    =chatalysis
+    = chatalysis
 zip_safe = no
 
 [options.extras_require]


### PR DESCRIPTION
closes #80 

now when source is selected, not only chat_ids but also all their relevant paths are loaded (relevant = containing json files)

regarding the if-statements in the _process_messages() for-loop, I actually don't think that they can be easily removed/the whole thing easily reworked since I want to keep participants as current participants but count stats from past participants to total chat stats

tzv. lgtm