### PR TITLE
🚑 adapt to FB data change

### DIFF
--- a/chatalysis/chats/stats.py
+++ b/chatalysis/chats/stats.py
@@ -38,7 +38,6 @@ class Stats(abc.ABC):
     people: dict[str, int]  # dict of people who sent messages in the chat and the number of their messages
     participants: list[str]  # list of chat participants
     title: str
-    total_call_duration: int  # duration in minutes
     nicknames: list[dict[str, Any]]
     group_names: list[dict[str, Any]]
     stats_type: StatsType

--- a/chatalysis/sources/facebook_source.py
+++ b/chatalysis/sources/facebook_source.py
@@ -316,6 +316,10 @@ class FacebookSource(MessageSource):
                 if any(x.endswith(".json") for x in list_folder(path_to_chat_folder)):
                     if "_" in chat_id:
                         chat_id = chat_id.split("_", 1)[1]
+                    else:
+                        # chats with deleted accounts don't contain a name and only consist of the chat ID
+                        continue
+
                     if chat_id in self.chat_ids:
                         self.chat_ids[chat_id].append(path_to_chat_folder)
                     else:

--- a/chatalysis/sources/facebook_source.py
+++ b/chatalysis/sources/facebook_source.py
@@ -15,6 +15,7 @@ from utils.const import EMOJIS_REGEX, EMOJIS_DICT, TRANSLATE_REMOVE_LETTERS
 from chats.stats import StatsType, FacebookStats
 from sources.message_source import MessageSource, NoMessageFilesError
 from utils.utility import list_folder
+
 if TYPE_CHECKING:
     from gui.main_gui import MainGUI
 
@@ -130,7 +131,7 @@ class FacebookSource(MessageSource):
                 participants.extend(self.messages_cache[chat_id][1])
 
             if gui:
-                gui.progress_bar["value"] += 1/len(self.chat_ids) * 100
+                gui.progress_bar["value"] += 1 / len(self.chat_ids) * 100
                 gui.update()
 
         # find the user's name (the one that appears in all conversations)
@@ -224,10 +225,10 @@ class FacebookSource(MessageSource):
                     title = ud.normalize("NFC", self._decode(data["title"]))
                     participants = self._get_participants(data)
 
-                    if data["thread_type"] == "RegularGroup":
-                        chat_type = StatsType.GROUP
-                    else:
+                    if len(participants) == 2:
                         chat_type = StatsType.REGULAR
+                    else:
+                        chat_type = StatsType.GROUP
 
                     get_current_info = False
 

--- a/chatalysis/sources/instagram.py
+++ b/chatalysis/sources/instagram.py
@@ -34,7 +34,6 @@ class Instagram(FacebookSource):
         reactions: Any = {"total": 0, "types": {}, "gave": {}, "got": {}}
         emojis: Any = {"total": 0, "types": {}, "sent": {}}
         message_lengths: dict[str, list[int]] = {}  # list of message lengths (in words) from a given person
-        total_call_duration = 0
 
         days = self._days_list(messages)
         months: dict[str, int] = {}
@@ -66,10 +65,6 @@ class Instagram(FacebookSource):
                 people[name] = 1 + people.get(name, 0)
             if "content" in m:
                 if name in participants:
-                    if m["type"] == "Call":
-                        total_call_duration += int(m["call_duration"])
-                        continue
-
                     emojis = self._extract_emojis(m, emojis)
                     # kept here for later
                     # words_cnt = len(regex.findall(r"(\b[^\s]+\b)", m["content"]))  # length of the message in words
@@ -116,7 +111,6 @@ class Instagram(FacebookSource):
             people,
             participants,
             title,
-            total_call_duration // 60,
             None,
             None,
             stats_type,

--- a/chatalysis/sources/messenger.py
+++ b/chatalysis/sources/messenger.py
@@ -44,7 +44,6 @@ class Messenger(FacebookSource):
         reactions: Any = {"total": 0, "types": {}, "gave": {}, "got": {}}
         emojis: Any = {"total": 0, "types": {}, "sent": {}}
         message_lengths: dict[str, list[int]] = {}  # list of message lengths (in words) from a given person
-        total_call_duration = 0
         nicknames: list[dict[str, Any]] = []
         group_names: list[dict[str, Any]] = []
 
@@ -89,10 +88,6 @@ class Messenger(FacebookSource):
                         continue
 
                 if name in participants:
-                    if m["type"] == "Call":
-                        total_call_duration += int(m["call_duration"])
-                        continue
-
                     emojis = self._extract_emojis(m, emojis)
                     # kept here for later
                     # words_cnt = len(regex.findall(r"(\b[^\s]+\b)", m["content"]))  # length of the message in words
@@ -148,7 +143,6 @@ class Messenger(FacebookSource):
             people,
             participants,
             title,
-            total_call_duration // 60,
             nicknames,
             group_names,
             stats_type,


### PR DESCRIPTION
FB changed some data format, spotted by @kartol but not fixed by him :(
- removed thread_type which we used to distinguish between groupchat and regular chat (current fix assumes regular chat == 2 participants, groupchat != 2)
- removed type from message (so I removed call duration count, we didn't use it anyway)